### PR TITLE
Fix Cliente model import path

### DIFF
--- a/src/app/components/importar-clientes/importar-clientes.component.ts
+++ b/src/app/components/importar-clientes/importar-clientes.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import * as XLSX from 'xlsx';
-import { Cliente } from '../.././models/cliente.model';
+import { Cliente } from '../../models/cliente.model';
 import { inject } from '@angular/core';
 import { ClientesService } from '../../services/clientes.service';
 import { ToastService } from '../../services/toast.service';


### PR DESCRIPTION
## Summary
- fix path to cliente model in ImportarClientesComponent

## Testing
- `npx tsc src/app/components/importar-clientes/importar-clientes.component.ts --lib es2022,dom --skipLibCheck --noEmit --pretty false`


------
https://chatgpt.com/codex/tasks/task_e_6853f2476798833094384add54bc2dcc