### PR TITLE
Fix cliente addition without empty id

### DIFF
--- a/src/app/components/clientes-list/clientes-list.component.ts
+++ b/src/app/components/clientes-list/clientes-list.component.ts
@@ -27,18 +27,18 @@ export class ClientesListComponent {
   }
 
   mostrarModal = false;
-  cliente: Cliente = { id: '', nombre: '', telefono: '', email: '', direccion: '' };
+  cliente: Cliente = { nombre: '', telefono: '', email: '', direccion: '' };
 
   readonly clientes = this.clientesService.clientes;
 
   abrirModal() {
     this.mostrarModal = true;
-    this.cliente = { id: '', nombre: '', telefono: '', email: '', direccion: '' };
+    this.cliente = { nombre: '', telefono: '', email: '', direccion: '' };
   }
 
   cerrarModal() {
     this.mostrarModal = false;
-    this.cliente = { id: '', nombre: '', telefono: '', email: '', direccion: '' };
+    this.cliente = { nombre: '', telefono: '', email: '', direccion: '' };
   }
 
   async guardar() {
@@ -47,7 +47,7 @@ export class ClientesListComponent {
       if (id) {
         await this.clientesService.actualizar(this.cliente);
       } else {
-        await this.clientesService.agregar(this.cliente);
+        await this.clientesService.agregar({ nombre, telefono, email, direccion });
       }
       this.cerrarModal();
     }


### PR DESCRIPTION
## Summary
- init new cliente objects without an `id` field
- ensure new cliente calls to `agregar` omit the empty `id`

## Testing
- `npm install -g @angular/cli`
- `npm install`
- `npm test` *(fails: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_6853f33034f083309a475fc0bd317e8d