### PR TITLE
Update README e2e section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,10 @@ ng test
 
 ## Running end-to-end tests
 
-For end-to-end (e2e) testing, run:
-
-```bash
-ng e2e
-```
-
-Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
+This project does not include an end-to-end (e2e) testing framework out of the box.
+Before you can run e2e tests you will need to install and configure one, such as
+[Cypress](https://www.cypress.io/) or [Protractor](https://github.com/angular/protractor).
+Refer to the chosen framework's documentation for setup and usage instructions.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary
- clarify that the repo doesn't include an e2e framework

## Testing
- `npm install`
- `npm test --silent` *(fails: no spec files)*

------
https://chatgpt.com/codex/tasks/task_e_6853f3f3d66483309a34862e22c00aed