### PR TITLE
Fix Excel import field names

### DIFF
--- a/src/app/components/importar-clientes/importar-clientes.component.ts
+++ b/src/app/components/importar-clientes/importar-clientes.component.ts
@@ -27,10 +27,10 @@ export class ImportarClientesComponent {
       const jsonData = XLSX.utils.sheet_to_json(sheet);
 
       const clientesImportados: Cliente[] = (jsonData as any[]).map(row => ({
-        nombre: row.nombre || '',
-        telefono: row.telefono || '',
-        email: row.email || '',
-        direccion: row.direccion || '',
+        nombre: row.nombre || row.Nombre || '',
+        telefono: row.telefono || row.Teléfono || row.Telefono || '',
+        email: row.email || row.Email || '',
+        direccion: row.direccion || row.Dirección || row.Direccion || '',
       }));
 
       const validos = clientesImportados.filter(


### PR DESCRIPTION
## Summary
- adjust import parsing to handle headers from exported Excel files

## Testing
- `npm test` *(fails: error TS18003 - no inputs were found in tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f73fb16f483309738577bab48159f