### PR TITLE
Add toast service unit test

### DIFF
--- a/src/app/services/toast.service.spec.ts
+++ b/src/app/services/toast.service.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ToastService } from './toast.service';
+
+describe('ToastService', () => {
+  let service: ToastService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ToastService);
+  });
+
+  it('should set and clear mensaje when mostrar is called', fakeAsync(() => {
+    service.mostrar('hi', 1000);
+    expect(service.mensaje()).toBe('hi');
+    tick(1000);
+    expect(service.mensaje()).toBe('');
+  }));
+});


### PR DESCRIPTION
## Summary
- add a Jasmine spec for `ToastService`

## Testing
- `npm install`
- `npx ng test --watch=false --no-progress` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6853f4cf4ba88330aa8acd2607645345