### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,10 @@
 # AgendaClientes
 
-This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 19.2.13.
+AgendaClientes is a small contact management application built with Angular. It allows you to keep a list of clients, edit their details and export the information to Excel. The data is loaded from a local JSON file so you can test the app without a backend.
 
-## Development server
+## Features
 
-To start a local development server, run:
-
-```bash
-ng serve
-```
-
-Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
-
-## Code scaffolding
-
-Angular CLI includes powerful code scaffolding tools. To generate a new component, run:
-
-```bash
-ng generate component component-name
-```
-
-For a complete list of available schematics (such as `components`, `directives`, or `pipes`), run:
-
-```bash
-ng generate --help
-```
-
-## Building
-
-To build the project run:
-
-```bash
-ng build
-```
-
-This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
-
-## Running unit tests
-
-To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
-
-```bash
-ng test
-```
-
-## Running end-to-end tests
-
-This project does not include an end-to-end (e2e) testing framework out of the box.
-Before you can run e2e tests you will need to install and configure one, such as
-[Cypress](https://www.cypress.io/) or [Protractor](https://github.com/angular/protractor).
-Refer to the chosen framework's documentation for setup and usage instructions.
-
-## Additional Resources
-
-For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+- View, add and edit clients in a responsive list.
+- Remove entries with a confirmation dialog.
+- Export the client list to an Excel spreadsheet.
+- See a summary with statistics about your client base.


### PR DESCRIPTION
## Summary
- streamline README by removing Angular CLI scaffolding info

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd804805483308e9ae5e6b69ac3bc